### PR TITLE
sign gem rather than content

### DIFF
--- a/lib/rubygems/sigstore/http_client.rb
+++ b/lib/rubygems/sigstore/http_client.rb
@@ -32,7 +32,7 @@ class HttpClient
     return fulcio_response.body
   end
 
-  def submit_rekor(pub_key, data_digest, data_signature, certPEM, data_raw, rekor_host)
+  def submit_rekor(cert_chain, data_digest, data_signature, certPEM, data_raw, rekor_host)
     # rekor uses a self signed certificate which failes the ssl check
     connection = Faraday.new(ssl: { verify: false }) do |request|
       # request.authorization :Bearer, id_token.to_s
@@ -51,7 +51,7 @@ class HttpClient
                 format: "x509",
                     content: Base64.encode64(data_signature),
                     publicKey: {
-                      content: Base64.encode64(pub_key.to_pem),
+                      content: Base64.encode64(cert_chain),
                     },
               },
                 data: {


### PR DESCRIPTION
Update `gem build --sign` to sign the contents of the newly built gem file itself, instead of embedding signatures of the gem's data, metadata, and checksums into the archive.  The signature and fulcio cert chain are both included in a single Rekor record entry.

In a follow up PR, we'll refactor that logic into its own class, then call the self-contained bit in `gem sign` as well.