### PR TITLE
Sign gem

### DIFF
--- a/lib/rubygems/sigstore/http_client.rb
+++ b/lib/rubygems/sigstore/http_client.rb
@@ -16,7 +16,9 @@ require "faraday_middleware"
 require "openssl"
 
 class HttpClient
-  def initialize; end
+  def initialize
+  end
+
   def get_cert(id_token, proof, pub_key, fulcio_host)
     # rekor uses a self signed certificate which failes the ssl check
     connection = Faraday.new(ssl: { verify: false }) do |request|
@@ -29,6 +31,7 @@ class HttpClient
     fulcio_response = connection.post("/api/v1/signingCert", { publicKey: { content: pub_key, algorithm: "ecdsa" }, signedEmailAddress: proof})
     return fulcio_response.body
   end
+
   def submit_rekor(pub_key, data_digest, data_signature, certPEM, data_raw, rekor_host)
     # rekor uses a self signed certificate which failes the ssl check
     connection = Faraday.new(ssl: { verify: false }) do |request|

--- a/lib/rubygems/sigstore/http_client.rb
+++ b/lib/rubygems/sigstore/http_client.rb
@@ -32,7 +32,7 @@ class HttpClient
     return fulcio_response.body
   end
 
-  def submit_rekor(pub_key, data_digest, data_signature, certPEM, data_raw, rekor_host)
+  def submit_rekor(cert_chain, data_digest, data_signature, certPEM, data_raw, rekor_host)
     # rekor uses a self signed certificate which failes the ssl check
     connection = Faraday.new(ssl: { verify: false }) do |request|
       # request.authorization :Bearer, id_token.to_s
@@ -51,7 +51,7 @@ class HttpClient
                 format: "x509",
                     content: Base64.encode64(data_signature),
                     publicKey: {
-                      content: Base64.encode64(pub_key.to_pem),
+                      content: Base64.encode64(cert_chain),
                     },
               },
                 data: {

--- a/lib/rubygems/sigstore/sign_extend.rb
+++ b/lib/rubygems/sigstore/sign_extend.rb
@@ -69,69 +69,22 @@ class Gem::Commands::BuildCommand
       gemspec_file = find_gemspec
       spec = Gem::Specification::load(gemspec_file)
 
-      # Unwrap files for signing
-      File.open("#{spec.full_name}.gem", "rb") do |file|
-        Gem::Package::TarReader.new(file) do |tar|
-          tar.each do |entry|
-            if entry.file?
-              FileUtils.mkdir_p(File.dirname(entry.full_name))
-              File.open(entry.full_name, "wb") do |f|
-                f.write(entry.read)
-              end
-              File.chmod(entry.header.mode, entry.full_name)
-            end
-          end
-        end
-      end
-
-      puts ""
-      puts "  Updating #{spec.full_name}.gem with signed materials"
-
-      checksums_file = File.read('checksums.yaml.gz')
-      checksums_digest = OpenSSL::Digest::SHA256.new(checksums_file)
-      checksums_signature = priv_key.sign checksums_digest, checksums_file
-      File.open('checksums.yaml.gz.sig', 'wb') do |f|
-        f.write(checksums_signature)
-      end
-
-      metadata_file = File.read('metadata.gz')
-      metadata_digest = OpenSSL::Digest::SHA256.new(metadata_file)
-      metadata_signature = priv_key.sign metadata_digest, metadata_file
-      File.open('metadata.gz.sig', 'wb') do |f|
-        f.write(metadata_signature)
-      end
-
-      data_file = File.read('data.tar.gz')
-      data_digest = OpenSSL::Digest::SHA256.new(data_file)
-      data_signature = priv_key.sign data_digest, data_file
-      File.open('data.tar.gz.sig', 'wb') do |f|
-        f.write(data_signature)
-      end
-
-      gem_files = ["data.tar.gz", "data.tar.gz.sig", "metadata.gz", "metadata.gz.sig", "checksums.yaml.gz", "checksums.yaml.gz.sig"]
-
-      File.open("#{spec.full_name}_signed.gem", 'wb') do |file|
-        Gem::Package::TarWriter.new(file) do |tar|
-          gem_files.each do|file|
-            tar.add_file_simple(File.basename(file), 0o666, File.size(file)) do |io|
-              File.open(file, 'rb') {|f| io.write(f.read) }
-            end
-          end
-        end
-      end
+      gem_file_path = "#{spec.full_name}.gem"
+      gem_file_sig_path = "#{gem_file_path}.sig"
+      gem_file = File.read(gem_file_path)
+      gem_file_digest = OpenSSL::Digest::SHA256.new(gem_file)
+      gem_file_signature = priv_key.sign gem_file_digest, gem_file
 
       puts ""
       puts "  sigstore signing operation complete"
       puts ""
       puts "  sending signing manifests to rekor.."
       puts ""
-      rekor_response = HttpClient.new.submit_rekor(pub_key, data_digest, data_signature, certPEM, Base64.encode64(data_file), config.rekor_host)
+
+      rekor_response = HttpClient.new.submit_rekor(pub_key, gem_file_digest, gem_file_signature, certPEM, Base64.encode64(data_file), config.rekor_host)
       print "  rekor response: "
       puts rekor_response
-      #clean up
-      Open3.popen3("rm data.tar.gz data.tar.gz.sig metadata.gz metadata.gz.sig checksums.yaml.gz checksums.yaml.gz.sig") do |stdin, stdout, stderr, thread|
-        puts stdout.read.chomp
-      end
+
       puts "signed file: #{spec.full_name}_signed.gem"
     end
   end


### PR DESCRIPTION
Update `gem build --sign` to sign the contents of the newly built gem file itself, instead of embedding signatures of the gem's data, metadata, and checksums into the archive.  The signature and fulcio cert chain are both included in a single Rekor record entry.

In a follow up PR, we'll refactor that logic into its own class, then call the self-contained bit in `gem sign` as well.