### PR TITLE
Clean up some of the printed messages

### DIFF
--- a/lib/rubygems/commands/sign_command.rb
+++ b/lib/rubygems/commands/sign_command.rb
@@ -55,6 +55,12 @@ class Gem::Commands::SignCommand < Gem::Command
       gemfile: gemfile,
       config: Gem::Sigstore::Config.read
     ).run
-    pp rekor_entry
+    pp log_entry_url(rekor_entry)
+  end
+
+  private
+
+  def log_entry_url(rekor_entry)
+    "#{Gem::Sigstore::Config.read.rekor_host}/api/v1/log/entries/#{rekor_entry.keys.first}"
   end
 end

--- a/lib/rubygems/commands/verify_command.rb
+++ b/lib/rubygems/commands/verify_command.rb
@@ -32,7 +32,7 @@ class Gem::Commands::VerifyCommand < Gem::Command
 
   def execute
     gem_path = get_one_gem_name
-    puts "verify \"#{gem_path}\""
+    puts "Verifying #{gem_path}"
 
     raise Gem::CommandLineError, "#{gem_path} is not a file" unless File.file?(gem_path)
 

--- a/lib/rubygems/sigstore/gem_signer.rb
+++ b/lib/rubygems/sigstore/gem_signer.rb
@@ -13,10 +13,10 @@ class Gem::Sigstore::GemSigner
 
     yield if block_given?
 
-    io.puts "Fulcio cert chain"
+    io.puts "Fulcio certificate chain"
     io.puts cert
     io.puts
-    io.puts "sending signiture & certificate chain to rekor."
+    io.puts "Sending gem digest, signature & certificate chain to transparency log."
 
     Gem::Sigstore::FileSigner.new(
       file: gemfile,

--- a/lib/rubygems/sigstore/gem_verifier.rb
+++ b/lib/rubygems/sigstore/gem_verifier.rb
@@ -16,7 +16,7 @@ class Gem::Sigstore::GemVerifier
     rekords = rekord_entries.select { |entry| valid_signature?(entry, gemfile) }
 
     if rekords.empty?
-      io.puts "not :noice: thxkbye"
+      io.puts "No valid signatures found for digest #{gemfile.digest}"
     else
       io.puts ":noice:"
       print_signers(rekords)
@@ -53,6 +53,6 @@ class Gem::Sigstore::GemVerifier
   def email_list(emails)
     return emails.first if emails.size == 1
 
-    emails[...-1].join(", ") + " and #{emails.last}"
+    emails[0...-1].join(", ") + " and #{emails.last}"
   end
 end


### PR DESCRIPTION
Example output:
```
➜  ruby-sigstore git:(print-log-entry-url) ✗ gem verify constant_resolver-0.1.5.gem
Verifying constant_resolver-0.1.5.gem
No valid signatures found for digest 509339b15b7bb1f850284c6139ca49495b64ceaff289c8c597b73f72a2ae82d9
➜  ruby-sigstore git:(print-log-entry-url) ✗ gem sign constant_resolver-0.1.5.gem  
Fulcio certificate chain
-----BEGIN CERTIFICATE-----
MIIDdzCCAv2gAwIBAgITBM5PFieINf0Ma4BJObQxUPJ/KTAKBggqhkjOPQQDAzAq
MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx
MTEwMjEyMjcyNloXDTIxMTEwMjEyNDcyNVowADCCASIwDQYJKoZIhvcNAQEBBQAD
ggEPADCCAQoCggEBAN05Cau1pU8iylYmjJl4xVspLOkXBzLsZ3qskaDKSqcl7szo
8XQO3ySVrVtd69QzzHX1azjjN0a6RltBuaefuu0WS5MHBG11DoqgTItmUm/zL/HV
id9ZliaBHDdsxaiFN9/Et3y+j8xdvZsDdAKDDcX3DBiJeDs21N+dYX06YhLlYP3r
ro77DUAoJimht7/sjisExcz6aB22gtttjSiRuOQBb8C30DRrxDvjDAYrTf8J6xB9
QKBQsAl1ErGTGy/+VeQuB+zYh10am2fPa/7T86ZomXaLOwiHlDdSXRuDguSbqCPj
eOoZRwsqtyz3aMcjh/t9icRVx/m9v5ebGSBRnFkCAwEAAaOCAV8wggFbMA4GA1Ud
DwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0G
A1UdDgQWBBRsz+DnP2tMdtG4SCq2u33rKjqeoTAfBgNVHSMEGDAWgBTIxR0AQZok
KTJRJOsNrkrtSgbT7DCBjQYIKwYBBQUHAQEEgYAwfjB8BggrBgEFBQcwAoZwaHR0
cDovL3ByaXZhdGVjYS1jb250ZW50LTYwM2ZlN2U3LTAwMDAtMjIyNy1iZjc1LWY0
ZjVlODBkMjk1NC5zdG9yYWdlLmdvb2dsZWFwaXMuY29tL2NhMzZhMWU5NjI0MmI5
ZmNiMTQ2L2NhLmNydDAlBgNVHREBAf8EGzAZgRdyb2NoLmxlZmVidnJlQGdtYWls
LmNvbTAvBgorBgEEAYO/MAEBBCFodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGlu
ZS5jb20wCgYIKoZIzj0EAwMDaAAwZQIxAP5EQzfm1kJMEHSF+0KFTRN4UvoDbp8p
Ts/rETPrmrVImtsR8LCAX2Ql+xD53jxIxQIwcWbv06ej2z3OkYHso2Wil6Jfsfir
DfAH/Kvc0q5rUQcFp5NXRKWMlTaj6Ql0OHYe
-----END CERTIFICATE-----

-----BEGIN CERTIFICATE-----
MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAq
MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx
MDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUu
ZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSy
A7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0Jcas
taRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6Nm
MGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYE
FMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2u
Su1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJx
Ve/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uup
Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
-----END CERTIFICATE-----

Sending gem digest, signature & certificate chain to transparency log.
"https://rekor.sigstore.dev/api/v1/log/entries/0b086a950a67d5d9a5dfc1c24181c6d02d518d673159f18ba2b6ac0e57477a09"
➜  ruby-sigstore git:(print-log-entry-url) ✗ gem verify constant_resolver-0.1.5.gem
Verifying constant_resolver-0.1.5.gem
:noice:
Signed by non-maintainer: roch.lefebvre@gmail.com
```