### PR TITLE
add rubocop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,17 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-    - name: Run the default task
+    - name: Run Tests
       run: bundle exec rake
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+        bundler-cache: true
+    - name: Run Lint
+      run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'bundler/**/*'
     - 'lib/rubygems/resolver/molinillo/**/*'
     - 'pkg/**/*'
+    - 'vendor/bundle/**/*'
     - 'tmp/**/*'
   TargetRubyVersion: 2.3
 

--- a/lib/rubygems/sigstore/file_signer.rb
+++ b/lib/rubygems/sigstore/file_signer.rb
@@ -22,4 +22,3 @@ class Gem::Sigstore::FileSigner
     @signature ||= @pkey.private_key.sign @file.digest, @file.content
   end
 end
-

--- a/lib/rubygems/sigstore/fulcio_api.rb
+++ b/lib/rubygems/sigstore/fulcio_api.rb
@@ -11,9 +11,9 @@ class Gem::Sigstore::FulcioApi
     connection.post("/api/v1/signingCert", {
       publicKey: {
         content: Base64.encode64(pub_key),
-        algorithm: "ecdsa"
+        algorithm: "ecdsa",
       },
-      signedEmailAddress: Base64.encode64(proof)
+      signedEmailAddress: Base64.encode64(proof),
     }).body
   end
 

--- a/lib/rubygems/sigstore/gem_verifier.rb
+++ b/lib/rubygems/sigstore/gem_verifier.rb
@@ -14,9 +14,9 @@ class Gem::Sigstore::GemVerifier
   def run
     rekor_api = Gem::Sigstore::Rekor::Api.new(host: config.rekor_host)
     log_entries = rekor_api.where(data_digest: gemfile.digest)
-    rekords = log_entries.select { |entry| entry.kind == :rekord }
+    rekords = log_entries.select {|entry| entry.kind == :rekord }
 
-    valid_signature_rekords = rekords.select { |rekord| valid_signature?(rekord, gemfile) }
+    valid_signature_rekords = rekords.select {|rekord| valid_signature?(rekord, gemfile) }
 
     if valid_signature_rekords.empty?
       say "No valid signatures found for digest #{gemfile.digest}"

--- a/lib/rubygems/sigstore/rekor/api.rb
+++ b/lib/rubygems/sigstore/rekor/api.rb
@@ -65,4 +65,3 @@ class Gem::Sigstore::Rekor::Api
     end
   end
 end
-

--- a/lib/rubygems/sigstore/rekor/log_entry.rb
+++ b/lib/rubygems/sigstore/rekor/log_entry.rb
@@ -1,5 +1,4 @@
 class Gem::Sigstore::Rekor::LogEntry
-
   def self.from(entry_response)
     uuid = entry_response.keys.first
     entry = entry_response[uuid]

--- a/lib/rubygems/sigstore/rekor/rekord.rb
+++ b/lib/rubygems/sigstore/rekor/rekord.rb
@@ -2,7 +2,6 @@ require "rubygems/sigstore/cert_chain"
 require "rubygems/sigstore/rekor/log_entry"
 
 class Gem::Sigstore::Rekor::Rekord < Gem::Sigstore::Rekor::LogEntry
-
   def signature
     @signature ||= begin
       signature = Base64.decode64(body.dig("spec", "signature", "content"))

--- a/lib/rubygems/sigstore/rekor/rekord.rb
+++ b/lib/rubygems/sigstore/rekor/rekord.rb
@@ -33,4 +33,3 @@ class Gem::Sigstore::Rekor::Rekord < Gem::Sigstore::Rekor::LogEntry
     end
   end
 end
-

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,11 +21,10 @@ module Gem
     @ui = Gem::MockGemUi.new
   end
 
-
   class Gem::TestCase < Test::Unit::TestCase
     include Gem::DefaultUserInteraction
 
-    BASE64_ENCODED_PATTERN = /[a-zA-Z0-9\+\/=\\]/
+    BASE64_ENCODED_PATTERN = /[a-zA-Z0-9\+\/=\\]/.freeze
 
     def setup
       @back_ui = Gem::DefaultUserInteraction.ui

--- a/test/support/fulcio_helper.rb
+++ b/test/support/fulcio_helper.rb
@@ -2,7 +2,7 @@ module FulcioHelper
   include UrlHelper
   include SigstoreAuthHelper
 
-  FULCIO_BASE_URL = 'https://fulcio.sigstore.dev/'
+  FULCIO_BASE_URL = 'https://fulcio.sigstore.dev/'.freeze
 
   def fulcio_api_url(*path, **kwargs)
     url_regex(FULCIO_BASE_URL, 'api', 'v1', path, **kwargs)

--- a/test/support/rekor_helper.rb
+++ b/test/support/rekor_helper.rb
@@ -5,8 +5,8 @@ module RekorHelper
   include UrlHelper
   include FulcioHelper
 
-  REKOR_BASE_URL = 'https://rekor.sigstore.dev/'
-  REKOR_FAKE_CA_BASE_URL = 'http://some-ca-authority.org/'
+  REKOR_BASE_URL = 'https://rekor.sigstore.dev/'.freeze
+  REKOR_FAKE_CA_BASE_URL = 'http://some-ca-authority.org/'.freeze
 
   def rekor_api_url(*path, **kwargs)
     url_regex(REKOR_BASE_URL, 'api', 'v1', path, **kwargs)
@@ -34,23 +34,23 @@ module RekorHelper
                 content: BASE64_ENCODED_PATTERN,
                 publicKey: hash_including({
                   content: BASE64_ENCODED_PATTERN,
-                })
+                }),
               }),
               data: hash_including({
                 content: BASE64_ENCODED_PATTERN,
                 hash: hash_including({
                   algorithm: "sha256",
-                  value: gem.digest
-                })
-              })
-            })
+                  value: gem.digest,
+                }),
+              }),
+            }),
           }.merge(body) # deep_merge is incompatible with nested hash_including()
         )
       )
       .to_return_json(
         build_rekord_entry(returning[:body] || {}),
         {
-          status: 201
+          status: 201,
         }
       )
   end
@@ -63,9 +63,9 @@ module RekorHelper
         logID: "dummy rekord logID",
         logIndex: 864991,
         verification: {
-          signedEntryTimestamp: "dummy timestamp signature"
-        }
-      }
+          signedEntryTimestamp: "dummy timestamp signature",
+        },
+      },
     }.deep_merge(options)
   end
 
@@ -117,9 +117,9 @@ module RekorHelper
         logID: "dummy rekord logID",
         logIndex: 864991,
         verification: {
-          signedEntryTimestamp: "dummy timestamp signature"
-        }
-      }
+          signedEntryTimestamp: "dummy timestamp signature",
+        },
+      },
     }.deep_merge(log_entry_options)
   end
 
@@ -137,16 +137,16 @@ module RekorHelper
           "hash": {
             "algorithm": "sha256",
             "value": gem.digest,
-          }
+          },
         },
         "signature": {
           "content": Base64.encode64(pkey.private_key.sign(OpenSSL::Digest.new('SHA256'), gem.content)),
           "format": "x509",
           "publicKey": {
             "content": Base64.encode64(cert_chain.last),
-          }
-        }
-      }
+          },
+        },
+      },
     }.deep_merge(rekord_options)
   end
 

--- a/test/support/sigstore_auth_helper.rb
+++ b/test/support/sigstore_auth_helper.rb
@@ -1,7 +1,7 @@
 module SigstoreAuthHelper
   include UrlHelper
 
-  SIGSTORE_OAUTH2_BASE_URL = 'https://oauth2.sigstore.dev/'
+  SIGSTORE_OAUTH2_BASE_URL = 'https://oauth2.sigstore.dev/'.freeze
 
   def sigstore_auth_url(*path, **kwargs)
     url_regex(SIGSTORE_OAUTH2_BASE_URL, 'auth', path, **kwargs)
@@ -33,7 +33,7 @@ module SigstoreAuthHelper
       code_challenge_methods_supported: ["S256", "plain"],
       scopes_supported: ["openid", "email", "groups", "profile", "offline_access"],
       token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post"],
-      claims_supported: ["iss", "sub", "aud", "iat", "exp", "email", "email_verified", "locale", "name", "preferred_username", "at_hash"]
+      claims_supported: ["iss", "sub", "aud", "iat", "exp", "email", "email_verified", "locale", "name", "preferred_username", "at_hash"],
     }.merge(options)
   end
 
@@ -47,7 +47,7 @@ module SigstoreAuthHelper
     stub_request(:post, sigstore_auth_url('token'))
       .with(
         headers: {
-            authorization: 'Basic c2lnc3RvcmU6', #u: sigstore, no password.  From settings.yml
+          authorization: 'Basic c2lnc3RvcmU6', #u: sigstore, no password.  From settings.yml
             content_type: 'application/x-www-form-urlencoded',
         }.merge(headers),
         body: hash_including(
@@ -83,7 +83,7 @@ module SigstoreAuthHelper
 
   def build_sigstore_auth_keys(options)
     {
-      keys: [access_token_jwk]
+      keys: [access_token_jwk],
     }.merge(options)
   end
 

--- a/test/support/url_helper.rb
+++ b/test/support/url_helper.rb
@@ -1,19 +1,19 @@
 module UrlHelper
-  BASE64_ENCODED_PATTERN = /[a-zA-Z0-9\+\/=\\]/
+  BASE64_ENCODED_PATTERN = /[a-zA-Z0-9\+\/=\\]/.freeze
 
   def url_regex(base, *path, **kwargs)
-    escape = lambda { |v| v.is_a?(String) ? Regexp.escape(v) : v.to_s }
+    escape = lambda {|v| v.is_a?(String) ? Regexp.escape(v) : v.to_s }
 
     params = [base, path]
       .flatten
-      .map { |param| escape.call(param) }
+      .map {|param| escape.call(param) }
 
     url = File.join(params)
-    kwargs = kwargs.delete_if { |_, v| v.blank? }
+    kwargs = kwargs.delete_if {|_, v| v.blank? }
     unless kwargs.blank?
       url += Regexp.escape('?')
       query = kwargs
-        .map { |k, v| [escape.call(k), escape.call(v)].join('=') }
+        .map {|k, v| [escape.call(k), escape.call(v)].join('=') }
         .join('&')
       url += query
     end


### PR DESCRIPTION
fixes #6 

# Problem

I added rubocop to this repository in #2, but there it has to be run manually. Since it isn't an automatic change we will be prone to introduce regressions that will make it hard to integrate with rubygems later on.

# Solution

Setup rubocop to run in github actions for every PR.
I think it would make sense to copy the configuration from rubygems, which will reduce how much we will need to change once we propose to integrate the plugin into rubygems.
