### PR TITLE
Bulk-retrieve log entries by uuid

### DIFF
--- a/lib/rubygems/sigstore/rekor/log_entry.rb
+++ b/lib/rubygems/sigstore/rekor/log_entry.rb
@@ -1,7 +1,5 @@
 class Gem::Sigstore::Rekor::LogEntry
-  def self.from(entry_response)
-    uuid = entry_response.keys.first
-    entry = entry_response[uuid]
+  def self.from(uuid, entry)
     body = encoded_body_to_hash(entry["body"])
 
     case body["kind"]


### PR DESCRIPTION
Fixes #33

When we look up rekor log entries by digest, we may get several results.  This PR moves away from performing several `GET log/entries/{uuid}` requests in favour of a single `POST log/entries/retrieve { entryUUIDs: [uuids] }` request.

Most of the changes go into the test helpers.  We need to stub multi-uuid requests and responses.  I'm also adding a second `gem verify` integration test, where a gem has two signatures (i.e. two rekords for the same gem digest).

I'm not super happy with how the stubbing code is getting more verbose, but I'm ok with letting future-us iterate on it.