### PR TITLE
add static openid provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Or install it yourself as:
 
 `gem sign foo.gem`
 
+### Identity Tokens
+
+In automated environments, gem also supports directly using OIDC Identity Tokens from specific issuers.
+These can be supplied on the command line with the `--identity-token` flag.
+
+```shell
+$ gem sign sign --identity-token=$(gcloud auth print-identity-token)
+```
+
 ### Verify an existing gem file
 
 `gem verify foo.gem`

--- a/lib/rubygems/commands/sign_command.rb
+++ b/lib/rubygems/commands/sign_command.rb
@@ -23,6 +23,11 @@ require 'socket'
 class Gem::Commands::SignCommand < Gem::Command
   def initialize
     super "sign", "Sign a gem"
+
+    add_option("--identity-token", String,
+               "Provide a static token for automated environments") do |value, options|
+      options[:identity_token] = value
+    end
   end
 
   def arguments # :nodoc:
@@ -41,7 +46,8 @@ class Gem::Commands::SignCommand < Gem::Command
     gemfile = Gem::Sigstore::Gemfile.new(get_one_gem_name)
     rekor_entry = Gem::Sigstore::GemSigner.new(
       gemfile: gemfile,
-      config: Gem::Sigstore::Config.read
+      config: Gem::Sigstore::Config.read,
+      identity_token: options[:identity_token],
     ).run
     say log_entry_url(rekor_entry)
   end

--- a/lib/rubygems/commands/sign_extend.rb
+++ b/lib/rubygems/commands/sign_extend.rb
@@ -27,6 +27,11 @@ b.add_option("--sign", "Sign gem with sigstore.") do |value, options|
   Gem::Sigstore.options[:sign] = true
 end
 
+b.add_option("--identity-token", String,
+             "Provide a static token for automated environments") do |value, options|
+  Gem::Sigstore.options[:identity_token] = value
+end
+
 class Gem::Commands::BuildCommand
   alias_method :original_execute, :execute
   def execute
@@ -34,7 +39,8 @@ class Gem::Commands::BuildCommand
       gemfile = Gem::Sigstore::Gemfile.new(get_one_gem_name)
       gem_signer = Gem::Sigstore::GemSigner.new(
         gemfile: gemfile,
-        config: Gem::Sigstore::Config.read
+        config: Gem::Sigstore::Config.read,
+        identity_token: Gem::Sigstore.options[:identity_token],
       )
       # Run the gem build process only if openid auth was successful (original_execute)
       rekor_entry = gem_signer.run { original_execute }

--- a/lib/rubygems/sigstore/openid.rb
+++ b/lib/rubygems/sigstore/openid.rb
@@ -6,3 +6,4 @@ module Gem
 end
 
 require "rubygems/sigstore/openid/dynamic"
+require "rubygems/sigstore/openid/static"

--- a/lib/rubygems/sigstore/openid/static.rb
+++ b/lib/rubygems/sigstore/openid/static.rb
@@ -1,0 +1,73 @@
+class Gem::Sigstore::OpenID::Static
+  def initialize(priv_key, token)
+    @priv_key = priv_key
+    @unparsed_token = token
+  end
+
+  # https://www.youtube.com/watch?v=ZsgA77j5LyY
+  def proof
+    @proof ||= create_proof
+  end
+
+  def token
+    parse_token unless defined?(@token)
+    @token ||= @unparsed_token.to_s
+  end
+
+  private
+
+  def create_proof
+    pkey.sign_proof(subject)
+  end
+
+  def pkey
+    @pkey ||= Gem::Sigstore::PKey.new(private_key: @priv_key)
+  end
+
+  def parsed_token
+    @parsed_token ||= parse_token
+  end
+
+  def parse_token
+    begin
+      decoded_access_token = JSON::JWT.decode(@unparsed_token.to_s, public_keys)
+      JSON.parse(decoded_access_token.to_json)
+    rescue JSON::JWS::VerificationFailed => e
+      abort 'JWT Verification Failed: ' + e.to_s
+    end
+  end
+
+  def subject
+    return email if email
+
+    if parsed_token["subject"].empty?
+      abort 'No subject found in claims'
+    end
+
+    parsed_token["subject"]
+  end
+
+  def email
+    return unless parsed_token["email"]
+
+    # ensure that the OIDC provider has verified the email address
+    # note: this may have happened some time in the past
+    unless parsed_token["email_verified"]
+      abort 'Email address in OIDC token was not verified by identity provider'
+    end
+
+    parsed_token["email"]
+  end
+
+  def public_keys
+    @public_keys ||= oidc_discovery.jwks
+  end
+
+  def oidc_discovery
+    OpenIDConnect::Discovery::Provider::Config.discover! config.oidc_issuer
+  end
+
+  def config
+    Gem::Sigstore::Config.read
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,6 +2,7 @@ require 'test/unit'
 require 'webmock/test_unit'
 require 'rubygems/mock_gem_ui'
 require 'json/jwt'
+require 'byebug'
 
 require 'rubygems/sigstore'
 

--- a/test/test_sign_command.rb
+++ b/test/test_sign_command.rb
@@ -36,6 +36,24 @@ class TestSignCommand < Gem::TestCase
     assert_equal [], output
   end
 
+  def test_static_sign
+    @cmd.options[:args] = [@gem_path]
+    @cmd.options[:identity_token] = access_token
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Fulcio certificate chain", output.shift
+    assert_certificate(output) # root certificate
+    assert_certificate(output) # leaf certificate
+    assert_empty output.shift
+    assert_equal "Sending gem digest, signature & certificate chain to transparency log.", output.shift
+    assert_equal "https://rekor.sigstore.dev/api/v1/log/entries/dummy_entry_uuid", output.shift
+    assert_equal [], output
+  end
+
   def assert_certificate(output)
     assert_equal "-----BEGIN CERTIFICATE-----", output.shift
     assert_match BASE64_ENCODED_PATTERN, output.shift until output.first == "-----END CERTIFICATE-----"


### PR DESCRIPTION
# Problem

The current implementation of the id provider requires interaction with a web browser, which doesn't work in an automated environment.

# Solution

The folks over at sigstore/cosign solved this problem by allowing [cosign to accept an id token](https://github.com/sigstore/cosign/pull/335). This PR ports that approach over. 

At a later point (#42), we can also enable the usage of env variables, but that isn't required to get this tool working in ShipIt, which is the biggest unknown in my opinion. See https://github.com/sigstore/cosign/pull/644 for reference.

ref #24