### PR TITLE
Fix NoMethodError for `gem verify` on an unsigned gem

### DIFF
--- a/test/test_verify_command.rb
+++ b/test/test_verify_command.rb
@@ -14,6 +14,20 @@ class TestVerifyCommand < Gem::TestCase
     stub_rekor_get_rekords_by_uuid
   end
 
+  def test_unsigned_gem
+    @cmd.options[:args] = [@gem_path]
+    stub_rekor_search_index_by_digest(returning: [])
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Verifying #{@gem_path}", output.shift
+    assert_match /No valid signatures found for digest/, output.shift
+    assert_equal [], output
+  end
+
   def test_one_non_maintainer_signature
     @cmd.options[:args] = [@gem_path]
 


### PR DESCRIPTION
```
> gem verify ruby-sigstore-0.1.0.gemVerifying ruby-sigstore-0.1.0.gem
ERROR:  While executing gem ... (NoMethodError)
    undefined method `map' for nil:NilClass
```

When we look up rekor log entries by file digest, always call `response.body.reduce(:merge).map {...}` which blows up when `response.body` is an empty array (reduce then returns `nil`).

I'm making a few changes to support nonexistent signatures.  I'm also breaking up the `API#where` method into smaller chunks.
