### PR TITLE
add decision log

### DIFF
--- a/DECISIONLOG
+++ b/DECISIONLOG
@@ -1,0 +1,3 @@
+# 2021-12-15
+
+We decided to keep a decision log to capture key resolutions and make them available for future reference.


### PR DESCRIPTION
We decided to keep a decision log to capture key resolutions and make them available for future reference.