### PR TITLE
Rename `gem verify` to `gem verify_signatures`

### DIFF
--- a/lib/rubygems/commands/verify_signatures_command.rb
+++ b/lib/rubygems/commands/verify_signatures_command.rb
@@ -15,11 +15,11 @@
 require 'rubygems/command'
 require 'rubygems/sigstore'
 
-class Gem::Commands::VerifyCommand < Gem::Command
+class Gem::Commands::VerifySignaturesCommand < Gem::Command
   def initialize
-    super 'verify', "Opens the gem's documentation"
-    add_option('--rekor-host HOST', 'Rekor host') do |value, options|
-      options[:host] = value
+    super 'verify_signatures', "Verifies whether a gem has been signed via sigstore."
+    add_option('--rekor-host HOST', 'Rekor host (not implemented)') do |value, options|
+      options[:rekor_host] = value
     end
   end
 

--- a/lib/rubygems/commands/verify_signatures_extend.rb
+++ b/lib/rubygems/commands/verify_signatures_extend.rb
@@ -15,11 +15,11 @@
 require 'rubygems/command_manager'
 require 'rubygems/sigstore'
 
-Gem::CommandManager.instance.register_command :verify
+Gem::CommandManager.instance.register_command :verify_signatures
 
 # gem install hooks
 i = Gem::CommandManager.instance[:install]
-i.add_option("--[no-]verify",
+i.add_option("--[no-]verify-signatures",
              'Verifies a local gem has been signed via sigstore.' +
              'This helps to ensure the gem has not been tampered with in transit.') do |value, options|
   Gem::Sigstore.options[:verify] = value

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -16,12 +16,12 @@ require 'rubygems/command_manager'
 require 'rubygems/sigstore'
 require 'rubygems/commands/sign_command'
 require 'rubygems/commands/sign_extend'
-require 'rubygems/commands/verify_command'
-require 'rubygems/commands/verify_extend'
+require 'rubygems/commands/verify_signatures_command'
+require 'rubygems/commands/verify_signatures_extend'
 
 Gem::CommandManager.instance.register_command :sign
-Gem::CommandManager.instance.register_command :verify
+Gem::CommandManager.instance.register_command :verify_signatures
 
-[:sign, :verify, :build, :install].each do |cmd_name|
+[:sign, :verify_signatures, :build, :install].each do |cmd_name|
   cmd = Gem::CommandManager.instance[cmd_name]
 end

--- a/test/test_verify_signatures_command.rb
+++ b/test/test_verify_signatures_command.rb
@@ -1,14 +1,14 @@
 require 'helper'
-require "rubygems/commands/verify_command"
+require "rubygems/commands/verify_signatures_command"
 
-class TestVerifyCommand < Gem::TestCase
+class TestVerifySignaturesCommand < Gem::TestCase
   include RekorHelper
 
   def setup
     super
 
     @gem_path = gem_path("hello-world.gem")
-    @cmd = Gem::Commands::VerifyCommand.new
+    @cmd = Gem::Commands::VerifySignaturesCommand.new
 
     stub_rekor_search_index_by_digest
     stub_rekor_get_rekords_by_uuid


### PR DESCRIPTION
Closes #35, see issue for more context.

Renames `gem verify the_gem` to `gem verify_signatures the_gem`.  Please note that `gem verify` still works, since the `gem` client [generally accepts command substrings](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/command_manager.rb#L204-L212) as long as [they are unambiguous](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/command_manager.rb#L187-L196).

Renames `gem install --[no-]verify the_gem` to `gem install --[no-]verify-signatures`.

### 🎩 
