### PR TITLE
Add a `gem signatures` command

### DIFF
--- a/lib/rubygems/commands/signatures_command.rb
+++ b/lib/rubygems/commands/signatures_command.rb
@@ -1,0 +1,103 @@
+# Copyright 2021 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'rubygems/command'
+require 'rubygems/sigstore'
+
+require 'json/jwt'
+require 'launchy'
+require 'openid_connect'
+require 'socket'
+
+class Gem::Commands::SignaturesCommand < Gem::Command
+  SIGNING_OPTIONS = [:sign, :verify].freeze
+
+  def initialize
+    super "signatures", "Create and verify gem signatures"
+
+    add_option("-s", "--[no-]sign", "Sign the gem(s)") do |value, options|
+      options[:sign] = value
+    end
+
+    add_option("-v", "--[no-]verify", "Verify gem signatures") do |value, options|
+      options[:verify] = value
+    end
+
+    add_option("--identity-token TOKEN", String,
+               "Provide a static token for signing in automated environments") do |value, options|
+      options[:identity_token] = value
+    end
+  end
+
+  def arguments # :nodoc:
+    "GEMNAME        name of gem to sign or verify"
+  end
+
+  def defaults_str # :nodoc:
+    ""
+  end
+
+  # def usage # :nodoc:
+  #   "gem signatures GEMNAME"
+  # end
+
+  def execute
+    gem_path = get_one_gem_name
+    raise Gem::CommandLineError, "#{gem_path} is not a file" unless File.file?(gem_path)
+
+    gemfile = Gem::Sigstore::Gemfile.new(gem_path)
+
+    sign(gemfile) if options[:sign]
+    verify(gemfile) if verify_signatures?
+  end
+
+  private
+
+  def sign(gemfile)
+    rekor_entry = Gem::Sigstore::GemSigner.new(
+      gemfile: gemfile,
+      config: Gem::Sigstore::Config.read,
+      identity_token: options[:identity_token],
+    ).run
+
+    say log_entry_url(rekor_entry)
+  end
+
+  def verify_signatures?
+    if options.key?(:verify)
+      options[:verify]
+    else
+      default_verify_behavior
+    end
+  end
+
+  def default_verify_behavior
+    # Only verify signatures if there are no other signature-related options present.
+    options.slice(*SIGNING_OPTIONS).empty?
+  end
+
+  def verify(gemfile)
+    say "Verifying #{gemfile.path}"
+
+    verifier = Gem::Sigstore::GemVerifier.new(
+      gemfile: gemfile,
+      config: Gem::Sigstore::Config.read
+    )
+    verifier.run
+  end
+
+  def log_entry_url(rekor_entry)
+    "#{Gem::Sigstore::Config.read.rekor_host}/api/v1/log/entries/#{rekor_entry.keys.first}"
+  end
+end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -14,14 +14,16 @@
 
 require 'rubygems/command_manager'
 require 'rubygems/sigstore'
+require 'rubygems/commands/signatures_command'
 require 'rubygems/commands/sign_command'
 require 'rubygems/commands/sign_extend'
 require 'rubygems/commands/verify_command'
 require 'rubygems/commands/verify_extend'
 
+Gem::CommandManager.instance.register_command :signatures
 Gem::CommandManager.instance.register_command :sign
 Gem::CommandManager.instance.register_command :verify
 
-[:sign, :verify, :build, :install].each do |cmd_name|
+[:signatures, :sign, :verify, :build, :install].each do |cmd_name|
   cmd = Gem::CommandManager.instance[cmd_name]
 end

--- a/test/test_signatures_command.rb
+++ b/test/test_signatures_command.rb
@@ -1,0 +1,174 @@
+require 'helper'
+require "rubygems/commands/signatures_command"
+
+class TestSignaturesCommand < Gem::TestCase
+  include SigstoreAuthHelper
+  include FulcioHelper
+  include RekorHelper
+
+  def setup
+    super
+
+    @gem_path = gem_path("hello-world.gem")
+    @cmd = Gem::Commands::SignaturesCommand.new
+  end
+
+  def test_no_options
+    @cmd.handle_options %W[#{@gem_path}]
+    stub_rekor_search_index_by_digest(returning: [])
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Verifying #{@gem_path}", output.shift
+    assert_match /No valid signatures found for digest/, output.shift
+    assert_equal [], output
+  end
+
+  def test_sign
+    @cmd.handle_options %W[--sign #{@gem_path}]
+    stub_signing
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Fulcio certificate chain", output.shift
+    assert_certificate(output) # root certificate
+    assert_certificate(output) # leaf certificate
+    assert_empty output.shift
+    assert_equal "Sending gem digest, signature & certificate chain to transparency log.", output.shift
+    assert_equal "https://rekor.sigstore.dev/api/v1/log/entries/dummy_entry_uuid", output.shift
+    assert_equal [], output
+  end
+
+  def test_static_sign
+    @cmd.handle_options %W[--sign --identity-token #{access_token} #{@gem_path}]
+    stub_signing
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Fulcio certificate chain", output.shift
+    assert_certificate(output) # root certificate
+    assert_certificate(output) # leaf certificate
+    assert_empty output.shift
+    assert_equal "Sending gem digest, signature & certificate chain to transparency log.", output.shift
+    assert_equal "https://rekor.sigstore.dev/api/v1/log/entries/dummy_entry_uuid", output.shift
+    assert_equal [], output
+  end
+
+  def test_verify_unsigned_gem
+    @cmd.handle_options %W[--verify #{@gem_path}]
+    stub_rekor_search_index_by_digest(returning: [])
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Verifying #{@gem_path}", output.shift
+    assert_match /No valid signatures found for digest/, output.shift
+    assert_equal [], output
+  end
+
+  def test_one_non_maintainer_signature
+    @cmd.handle_options %W[--verify #{@gem_path}]
+    stub_rekor_search_index_by_digest
+    stub_rekor_get_rekords_by_uuid
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Verifying #{@gem_path}", output.shift
+    assert_equal ":noice:", output.shift
+    assert_equal "Signed by non-maintainer: someone@example.org", output.shift
+    assert_equal [], output
+  end
+
+  def test_maintainer_signature_and_non_maintainer_signature
+    @cmd.handle_options %W[--verify #{@gem_path}]
+    uuids = ["maintainer_entry_uuid", "dummy_entry_uuid"]
+    stub_rekor_search_index_by_digest(returning: uuids)
+    stub_rekor_get_rekords_by_uuid(
+      uuids: uuids,
+      returning: {
+        uuids.first => {
+          cert_options: {
+            email: "rubygems.org@n13.org", # email set in the spec for hello-world.gem
+          },
+        },
+        uuids.last => {},
+      }
+    )
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Verifying #{@gem_path}", output.shift
+    assert_equal ":noice:", output.shift
+    assert_equal "Signed by maintainer: rubygems.org@n13.org", output.shift
+    assert_equal "Signed by non-maintainer: someone@example.org", output.shift
+    assert_equal [], output
+  end
+
+  def test_sign_and_verify
+    @cmd.handle_options %W[--sign --verify #{@gem_path}]
+    stub_signing
+    stub_rekor_search_index_by_digest
+    stub_rekor_get_rekords_by_uuid
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Fulcio certificate chain", output.shift
+    assert_certificate(output) # root certificate
+    assert_certificate(output) # leaf certificate
+    assert_empty output.shift
+    assert_equal "Sending gem digest, signature & certificate chain to transparency log.", output.shift
+    assert_equal "https://rekor.sigstore.dev/api/v1/log/entries/dummy_entry_uuid", output.shift
+    assert_equal "Verifying #{@gem_path}", output.shift
+    assert_equal ":noice:", output.shift
+    assert_equal "Signed by non-maintainer: someone@example.org", output.shift
+    assert_equal [], output
+  end
+
+  def test_nonexistent_file
+    @cmd.handle_options %W[not_a_file]
+
+    use_ui @ui do
+      e = assert_raise Gem::CommandLineError do
+        @cmd.execute
+      end
+
+      assert_equal "not_a_file is not a file", e.message
+    end
+  end
+
+  def assert_certificate(output)
+    assert_equal "-----BEGIN CERTIFICATE-----", output.shift
+    assert_match BASE64_ENCODED_PATTERN, output.shift until output.first == "-----END CERTIFICATE-----"
+    assert_equal "-----END CERTIFICATE-----", output.shift
+  end
+
+  def stub_signing(gems: [@gem_path])
+    stub_sigstore_auth_get_openid_config
+    stub_sigstore_auth_create_token
+    stub_sigstore_auth_get_keys
+    stub_fulcio_create_signing_cert
+    gems.each do |gem|
+      stub_rekor_create_rekord(gem_path: gem)
+    end
+  end
+end


### PR DESCRIPTION
Closes #35, replaces #49.  I will update #35 with our discussion and decisions.

## 🎩 
### Help (proper copy and USAGE will come in later PRs)
```
➜  ruby-sigstore git:(add-signatures-command) ✗ gem help signatures
Usage: gem signatures [options]

  Options:
    -s, --[no-]sign                  Sign the gem(s)
    -v, --[no-]verify                Verify gem signatures
        --identity-token TOKEN       Provide a static token for signing in automated environments


  Common Options:
    -h, --help                       Get help on this command
    -V, --[no-]verbose               Set the verbose level of output
    -q, --quiet                      Silence command progress meter
        --silent                     Silence RubyGems output
        --config-file FILE           Use this config file instead of default
        --backtrace                  Show stack backtrace on errors
        --debug                      Turn on Ruby debugging
        --norc                       Avoid loading any .gemrc file


  Arguments:
    GEMNAME        name of gem to sign or verify

  Summary:
    Create and verify gem signatures
```
### Default command behaviour: --verify
```
➜  ruby-sigstore git:(add-signatures-command) ✗ gem signatures ruby-sigstore-0.1.0.gem
Verifying ruby-sigstore-0.1.0.gem
No valid signatures found for digest 394e2309bc47021c09322e89127527b10f930768e7951b1c215480408468b532
```
### Short and long forms for --verify
```
➜  ruby-sigstore git:(add-signatures-command) ✗ gem signatures -v ruby-sigstore-0.1.0.gem
Verifying ruby-sigstore-0.1.0.gem
No valid signatures found for digest 394e2309bc47021c09322e89127527b10f930768e7951b1c215480408468b532
➜  ruby-sigstore git:(add-signatures-command) ✗ gem signatures --verify ruby-sigstore-0.1.0.gem
Verifying ruby-sigstore-0.1.0.gem
No valid signatures found for digest 394e2309bc47021c09322e89127527b10f930768e7951b1c215480408468b532
```
### Long form for --sign (signing with my @shopify address)
```
➜  ruby-sigstore git:(add-signatures-command) ✗ gem signatures --sign ruby-sigstore-0.1.0.gem
Fulcio certificate chain
-----BEGIN CERTIFICATE-----
[REDACTED]
-----END CERTIFICATE-----

-----BEGIN CERTIFICATE-----
MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAq
MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx
MDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUu
ZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSy
A7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0Jcas
taRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6Nm
MGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYE
FMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2u
Su1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJx
Ve/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uup
Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
-----END CERTIFICATE-----

Sending gem digest, signature & certificate chain to transparency log.
https://rekor.sigstore.dev/api/v1/log/entries/1df847bd45d8[...]7731937495475
```
### Verify works when the gem is signed
```
➜  ruby-sigstore git:(add-signatures-command) ✗ gem signatures --verify ruby-sigstore-0.1.0.gem
Verifying ruby-sigstore-0.1.0.gem
:noice:
Signed by non-maintainer: roch.lefebvre@shopify.com
```
### Sign and then verify in the same command (signing with my @gmail address)
```
➜  ruby-sigstore git:(add-signatures-command) ✗ gem signatures --sign --verify ruby-sigstore-0.1.0.gem
Fulcio certificate chain
-----BEGIN CERTIFICATE-----
[REDACTED]
-----END CERTIFICATE-----

-----BEGIN CERTIFICATE-----
MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAq
MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx
MDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUu
ZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSy
A7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0Jcas
taRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6Nm
MGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYE
FMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2u
Su1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJx
Ve/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uup
Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
-----END CERTIFICATE-----

Sending gem digest, signature & certificate chain to transparency log.
https://rekor.sigstore.dev/api/v1/log/entries/0c55848e4fa[...]3dba24fd0cf662647f48b2
Verifying ruby-sigstore-0.1.0.gem
:noice:
Signed by non-maintainers: re.dacted@gmail.com and roch.lefebvre@shopify.com
```