### PR TITLE
Rename `install` command's --verify option to --verify-signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ gem signatures --sign --identity-token=$(gcloud auth print-identity-token)
 
 ### Install and verify a gem
 
-`gem install foo --verify`
+`gem install foo --verify-signatures`
 
 ## Development
 

--- a/lib/rubygems/commands/install_command_extend.rb
+++ b/lib/rubygems/commands/install_command_extend.rb
@@ -18,7 +18,7 @@ require 'rubygems/sigstore'
 
 # gem install hooks
 i = Gem::CommandManager.instance[:install]
-i.add_option("--[no-]verify",
+i.add_option("--[no-]verify-signatures",
              'Verifies a local gem has been signed via sigstore.' +
              'This helps to ensure the gem has not been tampered with in transit.') do |value, options|
   Gem::Sigstore.options[:verify] = value


### PR DESCRIPTION
## TODO: rebase once #53 has merged

Quick follow up to #50.  Note that in https://github.com/Shopify/ruby-sigstore/issues/35#issuecomment-996765248 we had decided to go with `gem install --signing-policy` as a way to find & validate signatures.  However, in this PR, we're going with `gem install --verify-signatures`. 

Until we have a better idea about how policies will work, `--verify-signatures` is clearer for end users.  We can definitely revisit this later anyway.