### PR TITLE
Validate file is a gem on signature command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.6
-          - 2.7
-          - 3.0
+          - '2.6'
+          - '2.7'
+          - '3.0'
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "oa-openid", "~> 0.0.2"
 gem "omniauth-openid", "~> 2.0.1"
 gem "ruby-openid-apps-discovery", "~> 1.2.0"
 gem "json-jwt", "~> 1.13.0"
+gem 'net-smtp', require: false
 
 group :development do
   gem "rubocop", "~> 0.80.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
     crack (0.4.5)
       rexml
     deep_merge (1.2.1)
+    digest (3.1.0)
     dry-configurable (0.12.1)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5.0)
@@ -86,6 +87,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
+    io-wait (0.2.1)
     jaro_winkler (1.5.4)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
@@ -98,6 +100,13 @@ GEM
     mini_mime (1.1.2)
     minitest (5.14.4)
     multipart-post (2.1.1)
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
     oa-core (0.0.3)
       rack
     oa-openid (0.0.2)
@@ -164,6 +173,7 @@ GEM
       httpclient (>= 2.4)
     test-unit (3.5.0)
       power_assert
+    timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
@@ -191,6 +201,7 @@ DEPENDENCIES
   config (~> 3.1.0)
   faraday_middleware (~> 1.0.0)
   json-jwt (~> 1.13.0)
+  net-smtp
   oa-openid (~> 0.0.2)
   omniauth-openid (~> 2.0.1)
   pp (= 0.2.0)

--- a/lib/rubygems/commands/install_command_extend.rb
+++ b/lib/rubygems/commands/install_command_extend.rb
@@ -34,8 +34,6 @@ Gem.pre_install do |installer|
 
         installer.say "Verifying #{gem_path}"
 
-        raise Gem::CommandLineError, "#{gem_path} is not a file" unless File.file?(gem_path)
-
         gemfile = Gem::Sigstore::Gemfile.new(gem_path)
         verifier = Gem::Sigstore::GemVerifier.new(
           gemfile: gemfile,

--- a/lib/rubygems/commands/signatures_command.rb
+++ b/lib/rubygems/commands/signatures_command.rb
@@ -55,6 +55,7 @@ class Gem::Commands::SignaturesCommand < Gem::Command
   def execute
     gem_path = get_one_gem_name
     raise Gem::CommandLineError, "#{gem_path} is not a file" unless File.file?(gem_path)
+    raise Gem::CommandLineError, "#{gem_path} is not a valid gem" unless is_a_gem?(gem_path)
 
     gemfile = Gem::Sigstore::Gemfile.new(gem_path)
 
@@ -63,6 +64,14 @@ class Gem::Commands::SignaturesCommand < Gem::Command
   end
 
   private
+
+  def is_a_gem?(file)
+    begin
+      Gem::Package.new(file).verify
+    rescue Gem::Package::FormatError
+      return false
+    end
+  end
 
   def sign(gemfile)
     rekor_entry = Gem::Sigstore::GemSigner.new(

--- a/test/fixtures/not_a_gem
+++ b/test/fixtures/not_a_gem
@@ -1,0 +1,1 @@
+This is used to test logic which determines whether a given file is a gem.

--- a/test/test_signatures_command.rb
+++ b/test/test_signatures_command.rb
@@ -156,6 +156,18 @@ class TestSignaturesCommand < Gem::TestCase
     end
   end
 
+  def test_rejects_files_that_are_not_gems
+    @cmd.handle_options %W[./test/fixtures/not_a_gem]
+
+    use_ui @ui do
+      e = assert_raise Gem::CommandLineError do
+        @cmd.execute
+      end
+
+      assert_equal "./test/fixtures/not_a_gem is not a valid gem", e.message
+    end
+  end
+
   def assert_certificate(output)
     assert_equal "-----BEGIN CERTIFICATE-----", output.shift
     assert_match BASE64_ENCODED_PATTERN, output.shift until output.first == "-----END CERTIFICATE-----"


### PR DESCRIPTION
Previously, we could sign any random file. However, when the verification retrieved and verified the signature, it would blow up. This makes it so that the gemminess of a file is verified before we sign it, so that only legit gems can be signed. 

Closes https://github.com/Shopify/ruby-sigstore/issues/37