### PR TITLE
Check responses from Fulcio/Rekor POSTs, raise unless expected

### DIFF
--- a/lib/rubygems/sigstore/fulcio_api.rb
+++ b/lib/rubygems/sigstore/fulcio_api.rb
@@ -8,13 +8,20 @@ class Gem::Sigstore::FulcioApi
   end
 
   def create(pub_key)
-    connection.post("/api/v1/signingCert", {
+    response = connection.post("/api/v1/signingCert", {
       publicKey: {
         content: Base64.encode64(pub_key),
         algorithm: "ecdsa",
       },
-      signedEmailAddress: Base64.encode64(oidp.proof),
-    }).body
+        signedEmailAddress: Base64.encode64(oidp.proof),
+    }
+    )
+
+    unless response.status == 201
+      raise "Unexpected response from POST api/v1/signingCert:\n #{response.body}"
+    end
+
+    response.body
   end
 
   private

--- a/lib/rubygems/sigstore/rekor/api.rb
+++ b/lib/rubygems/sigstore/rekor/api.rb
@@ -8,7 +8,7 @@ class Gem::Sigstore::Rekor::Api
   end
 
   def create(cert_chain, data)
-    connection.post("/api/v1/log/entries",
+    response = connection.post("/api/v1/log/entries",
       {
         kind: "rekord",
         apiVersion: "0.0.1",
@@ -28,7 +28,14 @@ class Gem::Sigstore::Rekor::Api
             },
           },
         },
-      }).body
+      }
+    )
+
+    unless response.status == 201
+      raise "Unexpected response from POST api/v1/log/entries:\n #{response.body}"
+    end
+
+    response.body
   end
 
   def where(data_digest:)


### PR DESCRIPTION
Just a quick change to raise if Fulcio responds unexpectedly while creating a certificate, and if Rekor does so when creating a log entry.

I thought there was an issue in the backlog to handle this, but I can't find it.  Adding a note to flesh out later: https://github.com/Shopify/ruby-sigstore/projects/1#card-76792493