### PR TITLE
Store gem signatures in a hashedrekord

### DIFF
--- a/lib/rubygems/sigstore/gem_verifier.rb
+++ b/lib/rubygems/sigstore/gem_verifier.rb
@@ -14,7 +14,7 @@ class Gem::Sigstore::GemVerifier
   def run
     rekor_api = Gem::Sigstore::Rekor::Api.new(host: config.rekor_host)
     log_entries = rekor_api.where(data_digest: gemfile.digest)
-    rekords = log_entries.select {|entry| entry.kind == :rekord }
+    rekords = log_entries.select {|entry| %i[rekord hashedrekord].include?(entry.kind) }
 
     valid_signature_rekords = rekords.select {|rekord| valid_signature?(rekord, gemfile) }
 

--- a/lib/rubygems/sigstore/rekor.rb
+++ b/lib/rubygems/sigstore/rekor.rb
@@ -2,6 +2,7 @@ module Gem::Sigstore::Rekor
 end
 
 require "rubygems/sigstore/rekor/api"
+require "rubygems/sigstore/rekor/hashed_rekord"
 require "rubygems/sigstore/rekor/log_entry"
 require "rubygems/sigstore/rekor/rekord"
 require "rubygems/sigstore/rekor/signature"

--- a/lib/rubygems/sigstore/rekor.rb
+++ b/lib/rubygems/sigstore/rekor.rb
@@ -4,3 +4,4 @@ end
 require "rubygems/sigstore/rekor/api"
 require "rubygems/sigstore/rekor/log_entry"
 require "rubygems/sigstore/rekor/rekord"
+require "rubygems/sigstore/rekor/signature"

--- a/lib/rubygems/sigstore/rekor/api.rb
+++ b/lib/rubygems/sigstore/rekor/api.rb
@@ -10,7 +10,7 @@ class Gem::Sigstore::Rekor::Api
   def create(cert_chain, data)
     connection.post("/api/v1/log/entries",
       {
-        kind: "rekord",
+        kind: "hashedrekord",
         apiVersion: "0.0.1",
         spec: {
           signature: {
@@ -21,7 +21,6 @@ class Gem::Sigstore::Rekor::Api
             },
           },
           data: {
-            content: Base64.encode64(data.raw),
             hash: {
               algorithm: "sha256",
               value: data.digest,

--- a/lib/rubygems/sigstore/rekor/hashed_rekord.rb
+++ b/lib/rubygems/sigstore/rekor/hashed_rekord.rb
@@ -1,0 +1,6 @@
+require "rubygems/sigstore/rekor/log_entry"
+require "rubygems/sigstore/rekor/signature"
+
+class Gem::Sigstore::Rekor::HashedRekord < Gem::Sigstore::Rekor::LogEntry
+  include Gem::Sigstore::Rekor::Signature
+end

--- a/lib/rubygems/sigstore/rekor/log_entry.rb
+++ b/lib/rubygems/sigstore/rekor/log_entry.rb
@@ -3,6 +3,8 @@ class Gem::Sigstore::Rekor::LogEntry
     body = encoded_body_to_hash(entry["body"])
 
     case body["kind"]
+    when "hashedrekord"
+      Gem::Sigstore::Rekor::HashedRekord.new(uuid, entry)
     when "rekord"
       Gem::Sigstore::Rekor::Rekord.new(uuid, entry)
     else

--- a/lib/rubygems/sigstore/rekor/rekord.rb
+++ b/lib/rubygems/sigstore/rekor/rekord.rb
@@ -1,34 +1,6 @@
-require "rubygems/sigstore/cert_chain"
 require "rubygems/sigstore/rekor/log_entry"
+require "rubygems/sigstore/rekor/signature"
 
 class Gem::Sigstore::Rekor::Rekord < Gem::Sigstore::Rekor::LogEntry
-  def signature
-    @signature ||= begin
-      signature = Base64.decode64(body.dig("spec", "signature", "content"))
-      raise "Expecting a signature in #{body}" unless signature
-      signature
-    end
-  end
-
-  def cert_chain
-    Gem::Sigstore::CertChain.new(cert)
-  end
-
-  def signer_email
-    cert_chain.signing_cert.subject_alt_name
-  end
-
-  def signer_public_key
-    cert_chain.signing_cert.public_key
-  end
-
-  private
-
-  def cert
-    @cert ||= begin
-      cert = Base64.decode64(body.dig("spec", "signature", "publicKey", "content"))
-      raise "Expecting a publicKey in #{body}" unless cert
-      cert
-    end
-  end
+  include Gem::Sigstore::Rekor::Signature
 end

--- a/lib/rubygems/sigstore/rekor/signature.rb
+++ b/lib/rubygems/sigstore/rekor/signature.rb
@@ -1,0 +1,33 @@
+require "rubygems/sigstore/cert_chain"
+
+module Gem::Sigstore::Rekor::Signature
+  def signature
+    @signature ||= begin
+      signature = Base64.decode64(body.dig("spec", "signature", "content"))
+      raise "Expecting a signature in #{body}" unless signature
+      signature
+    end
+  end
+
+  def cert_chain
+    Gem::Sigstore::CertChain.new(cert)
+  end
+
+  def signer_email
+    cert_chain.signing_cert.subject_alt_name
+  end
+
+  def signer_public_key
+    cert_chain.signing_cert.public_key
+  end
+
+  private
+
+  def cert
+    @cert ||= begin
+      cert = Base64.decode64(body.dig("spec", "signature", "publicKey", "content"))
+      raise "Expecting a publicKey in #{body}" unless cert
+      cert
+    end
+  end
+end

--- a/test/support/rekor_helper.rb
+++ b/test/support/rekor_helper.rb
@@ -25,7 +25,7 @@ module RekorHelper
         },
         body: hash_including(
           {
-            kind: "rekord",
+            kind: "hashedrekord",
             apiVersion: "0.0.1",
             spec: hash_including({
               signature: hash_including({
@@ -36,7 +36,6 @@ module RekorHelper
                 }),
               }),
               data: hash_including({
-                content: BASE64_ENCODED_PATTERN,
                 hash: hash_including({
                   algorithm: "sha256",
                   value: gem.digest,


### PR DESCRIPTION
When uploading a signature into Rekor, we don't need to send the entire artifact contents if we use a [_hashed rekord_ ](https://github.com/sigstore/rekor/blob/main/pkg/types/hashedrekord/v0.0.1/hashedrekord_v0_0_1_schema.json#L33-L34)instead of a [_rekord_](https://github.com/sigstore/rekor/blob/main/pkg/types/rekord/v0.0.1/rekord_v0_0_1_schema.json#L89). This speeds up the signing operation for larger gem files.  It also removes any limit on the size of the signed gem (currently either 32MB or 128MB).

Besides having a new `type`, the resulting log entry body is the same.  Rekor does not keep a copy of the artifact itself.

See [this thread on sigstore Slack](https://sigstore.slack.com/archives/C01DGF0G8U9/p1643042871141600) if you can.